### PR TITLE
Replace i128 to get the same alignment on amd64 as arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/math/Cargo.toml
+++ b/math/Cargo.toml
@@ -11,7 +11,8 @@ repository = "https://github.com/jet-lab/program-libraries"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-uint = "0.9"
-thiserror = "1.0"
+# 0.9 requires rustc 1.56.1+, but bpf is using 1.56.0
+uint = "0.8"
+thiserror = "1.0.20"
 bytemuck = { version = "1.7", features = ["derive"] }
 static_assertions = "1.1.0"

--- a/math/src/number_128.rs
+++ b/math/src/number_128.rs
@@ -156,8 +156,7 @@ impl Mul<Number128> for Number128 {
 
 impl MulAssign<Number128> for Number128 {
     fn mul_assign(&mut self, rhs: Number128) {
-        i128::from_le_bytes(self.0).mul_assign(i128::from_le_bytes(rhs.0));
-        i128::from_le_bytes(self.0).div_assign(ONE);
+        self.0 = (i128::from_le_bytes(self.0) * i128::from_le_bytes(rhs.0) / ONE).to_le_bytes();
     }
 }
 
@@ -176,8 +175,7 @@ impl Div<Number128> for Number128 {
 
 impl DivAssign<Number128> for Number128 {
     fn div_assign(&mut self, rhs: Number128) {
-        i128::from_le_bytes(self.0).mul_assign(ONE);
-        i128::from_le_bytes(self.0).div_assign(i128::from_le_bytes(rhs.0));
+        self.0 = (i128::from_le_bytes(self.0) * ONE / i128::from_le_bytes(rhs.0)).to_le_bytes();
     }
 }
 
@@ -248,5 +246,36 @@ mod tests {
             Number128::from_decimal(3, 1),
             Number128::from_decimal(1, 1) * 3u64
         )
+    }
+
+    #[test]
+    fn test_add_assign_101_2() {
+        let mut a = Number128::from_decimal(101, 0);
+        a += Number128::from_decimal(2, 0);
+        assert_eq!(Number128::from_decimal(103, 0), a);
+    }
+
+    #[test]
+    fn test_sub_assign_101_2() {
+        let mut a = Number128::from_decimal(101, 0);
+        a -= Number128::from_decimal(2, 0);
+        assert_eq!(Number128::from_decimal(99, 0), a);
+    }
+
+    #[test]
+    fn test_mul_assign_101_2() {
+        let mut a = Number128::from_decimal(101, 0);
+        a *= Number128::from_decimal(2, 0);
+        assert_eq!(
+            i128::from_le_bytes(Number128::from_decimal(202, 0).0),
+            i128::from_le_bytes(a.0)
+        );
+    }
+
+    #[test]
+    fn test_div_assign_101_2() {
+        let mut a = Number128::from_decimal(101, 0);
+        a /= Number128::from_decimal(2, 0);
+        assert_eq!(Number128::from_decimal(505, -1), a);
     }
 }


### PR DESCRIPTION
This replaces i128 with [u8; 16]. We only use LE architectures, so this is safe. We don't have a constructor that takes the raw byte array, so that's an extra safety feature between different endian archs.